### PR TITLE
Minimal clone example with separate network namespace.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -5,3 +5,6 @@ hello_SOURCES = hello.cc
 
 bin_PROGRAMS += unsharenet
 unsharenet_SOURCES = unsharenet.cc
+
+bin_PROGRAMS += clonetest
+clonetest_SOURCES = clonetest.cc

--- a/clonetest.cc
+++ b/clonetest.cc
@@ -1,0 +1,41 @@
+#include <sys/wait.h>
+#include <sched.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string>
+
+int bash_exec(void *) {
+  printf("In child, execing bash\n");
+  char* argv[1];
+  argv[0] = const_cast<char*>(std::string("--login").c_str());
+  execvp("bash", argv);
+  return 0;           /* Child terminates now */
+}
+
+int main() {
+  /* Allocate stack for child */
+  char* stack = static_cast<char*>(malloc(65536));
+  if (stack == nullptr) {
+    perror("malloc");
+    exit(EXIT_FAILURE);
+  }
+  char* stack_top = stack + 65536;  /* Stack grows downward */
+
+  /* Clone child */
+  pid_t pid = clone(bash_exec, stack_top, CLONE_NEWNET | SIGCHLD, nullptr);
+  if (pid == -1) {
+    perror("clone");
+    exit(EXIT_FAILURE);
+  }
+  printf("clone() returned %ld\n", (long) pid);
+
+  /* Wait for child */
+  int status;
+  if (wait(&status) == -1) {
+    perror("wait");
+    exit(EXIT_FAILURE);
+  }
+  printf("child has terminated\n");
+  exit(EXIT_SUCCESS);
+}


### PR DESCRIPTION
Keith,

To bring you up to speed, Ravi had some issues getting clone+unshare to work. In short, the parent process (the clone caller) was terminating without wait()ing for the child process (the clone callee) to terminate. I think the clone system call needs SIGCHLD to be passed as a flag for wait() to work correctly. Otherwise, the callee is detached from the caller.

Ravi,

I have attached a minimal program that works. It clone()s bash in a new network namespace, just like your old program unsharenet, but using the clone command(). Also, because it wait()'s, it doesn't terminate until the spawned bash instance terminates. Once you clone() multiple programs, you should use waitpid() instead of wait() to wait on a specific child process.
