### PR TITLE
Never call exit() -- make sure everything is destroyed cleanly

### DIFF
--- a/child_process.cc
+++ b/child_process.cc
@@ -23,9 +23,10 @@ ChildProcess::ChildProcess( std::function<int()> && child_procedure )
 
     if ( pid_ == 0 ) { /* child */
         try {
-            exit( child_procedure() );
+            throw Exit( child_procedure() );
         } catch ( const Exception & e ) {
-            e.die();
+            e.perror();
+            throw Exit( EXIT_FAILURE );
         }
     }
 }

--- a/child_process.hh
+++ b/child_process.hh
@@ -11,6 +11,17 @@
 
 class ChildProcess
 {
+public:
+    class Exit
+    {
+    private:
+        int status_;
+
+    public:
+        Exit( const int s_status ) : status_( s_status ) {}
+        int status( void ) const { return status_; }
+    };
+
 private:
     pid_t pid_;
     bool running_, terminated_;

--- a/exception.hh
+++ b/exception.hh
@@ -3,7 +3,6 @@
 
 #include <string>
 #include <iostream>
-#include <unistd.h>
 #include <cstring>
 
 class Exception
@@ -20,11 +19,9 @@ public:
     : attempt_( s_attempt ), error_( strerror( errno ) )
   {}
 
-  void die( void ) const
+  void perror( void ) const
   {
-    std::cerr << "Exception: " << attempt_ << ": " << error_ << std::endl;
-    std::cerr << "Exiting on error.\n";
-    exit( EXIT_FAILURE );
+    std::cerr << attempt_ << ": " << error_ << std::endl;
   }
 };
 

--- a/forked-ferry.cc
+++ b/forked-ferry.cc
@@ -67,7 +67,10 @@ int main( void )
         TapDevice egress_tap( "egress" );
         return ferry( egress_tap.fd(), ingress_socket, container_process, 2500 );
     } catch ( const Exception & e ) {
-        e.die();
+        e.perror();
+        return EXIT_FAILURE;
+    } catch ( const ChildProcess::Exit & e ) {
+        return e.status();
     }
 
     return EXIT_SUCCESS;

--- a/simple-ferry.cc
+++ b/simple-ferry.cc
@@ -59,7 +59,8 @@ int main ( void )
 
         ferry( ingress_tap, egress_tap, 2500 );
     } catch ( const Exception & e ) {
-        e.die();
+        e.perror();
+        return EXIT_FAILURE;
     }
 
     return EXIT_SUCCESS;


### PR DESCRIPTION
Hi Ravi,

Here is a cleanup that makes sure we never call `exit()` (which is kind of abrupt and leaves it to the operating system to clean up after us).

Instead now we throw a `ChildProcess::Exit` exception. The exception propagates all the way back to `main()`, making sure that every object gets properly destroyed before we `return` from `main()`.

-Keith
