### PR TITLE
Dnsfixes

### DIFF
--- a/dnsoutsideproxytcp.cc
+++ b/dnsoutsideproxytcp.cc
@@ -37,7 +37,7 @@ void service_request( const Socket & server_socket )
             pollfds[ 0 ].events = outgoing_eof ? 0 : POLLIN;
             pollfds[ 1 ].events = server_eof   ? 0 : POLLIN;
 
-             if ( poll( &pollfds[ 1 ], 1, 20000 ) < 0 ) {
+             if ( poll( pollfds, 2, 20000 ) < 0 ) {
                 throw Exception( "poll" );
             }
             if ( pollfds[ 1 ].revents & POLLIN ) {


### PR DESCRIPTION
Ravi,

These commits address a few problems with dnsoutsideproxytcp:
(1) The argument to the lambda used in thread creation should be the output from the accept() function call. Otherwise, it will create a thread bomb, by creating an infinite number of threads all talking to one socket, i.e., listen_socket.
(2) The poll() function call is incorrect. I am happy to clarify this further if you want me to.
(3) We also need to handle the case where either side closes (FINs) the TCP connection. I have stolen the code from ourtube to handle this.
(4) The variable names server_socket and outgoing_socket are a little confusing and ambiguos. Maybe we can make the names a little longer? I haven't done this yet.

I am happy to clarify any of these points in greater detail if you need me to.
Anirudh
