### PR TITLE
Pedantic route

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -7,7 +7,7 @@ delayshell_SOURCES = exception.hh ezio.cc ezio.hh delayshell.cc \
 	child_process.hh child_process.cc signalfd.hh signalfd.cc \
 	socket.cc socket.hh address.cc address.hh \
 	ferry.hh ferry.cc system_runner.hh nat.hh \
-	socket_type.hh drop_privileges.hh
+	socket_type.hh drop_privileges.hh route.hh
 delayshell_LDADD = -lrt
 install-exec-hook:
 	chown root $(bindir)/delayshell

--- a/delayshell.cc
+++ b/delayshell.cc
@@ -7,9 +7,6 @@
 #include <fstream>
 #include <grp.h>
 #include <sys/ioctl.h>
-#include <linux/if.h>
-#include <arpa/inet.h>
-#include <net/route.h>
 
 #include "tundevice.hh"
 #include "exception.hh"
@@ -21,6 +18,7 @@
 #include "address.hh"
 #include "drop_privileges.hh"
 #include "file_descriptor.hh"
+#include "route.hh"
 
 using namespace std;
 
@@ -117,34 +115,7 @@ int main( int argc, char *argv[] )
                 }
 
                 /* Set route the pedantic way */
-                // set route struct to zero
-                struct rtentry route;
-                struct sockaddr_in *addr;
-                int err = 0;
-                memset(&route, 0, sizeof(route));
-
-                // assign the default gateway
-                addr = reinterpret_cast<struct sockaddr_in*>( &route.rt_gateway );
-                addr->sin_family = AF_INET;
-                addr->sin_addr.s_addr = inet_addr(egress_addr.c_str());
-
-                // assign the destination
-                addr = reinterpret_cast<struct sockaddr_in*>( &route.rt_dst );
-                addr->sin_family = AF_INET;
-                addr->sin_addr.s_addr = inet_addr("0.0.0.0");
-
-                // assign the destination mask
-                addr = reinterpret_cast<struct sockaddr_in*>( &route.rt_genmask);
-                addr->sin_family = AF_INET;
-                addr->sin_addr.s_addr = inet_addr("0.0.0.0");
-
-                // set the flags NET/UP
-                route.rt_flags = RTF_UP | RTF_GATEWAY;
-                // make the ioctl
-                if ((err = ioctl(sockfd.num(), SIOCADDRT, &route)) != 0) {
-                   perror("SIOCADDRT failed");
-                   return -1;
-                }
+                Route( move( sockfd ), egress_addr );
 
                 /* create inside listener socket for UDP dns requests */
                 Socket listener_socket_inside( SocketType::UDP );

--- a/route.hh
+++ b/route.hh
@@ -1,0 +1,49 @@
+/* -*-mode:c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+#ifndef ROUTE_HH
+#define ROUTE_HH
+
+#include <linux/if.h>
+#include <arpa/inet.h>
+#include <net/route.h>
+
+/* Setup default route */
+
+class Route
+{
+public:
+  Route( FileDescriptor sockfd, std::string default_gw )
+  {
+    /* http://blogs.nologin.es/rickyepoderi/index.php?/archives/8-Setting-Routes-Using-C.html */
+    // set route struct to zero
+    struct rtentry route;
+    struct sockaddr_in *addr;
+    int err = 0;
+    memset(&route, 0, sizeof(route));
+
+    // assign the default gateway
+    addr = reinterpret_cast<struct sockaddr_in*>( &route.rt_gateway );
+    addr->sin_family = AF_INET;
+    addr->sin_addr.s_addr = inet_addr(default_gw.c_str());
+
+    // assign the destination
+    addr = reinterpret_cast<struct sockaddr_in*>( &route.rt_dst );
+    addr->sin_family = AF_INET;
+    addr->sin_addr.s_addr = inet_addr("0.0.0.0");
+
+    // assign the destination mask
+    addr = reinterpret_cast<struct sockaddr_in*>( &route.rt_genmask );
+    addr->sin_family = AF_INET;
+    addr->sin_addr.s_addr = inet_addr("0.0.0.0");
+
+    // set the flags NET/UP
+    route.rt_flags = RTF_UP | RTF_GATEWAY;
+    // make the ioctl
+    if ((err = ioctl(sockfd.num(), SIOCADDRT, &route)) != 0) {
+       perror("SIOCADDRT failed");
+       exit(-1);
+    }
+  }
+};
+
+#endif /* NAT_HH */


### PR DESCRIPTION
Replace shelled-out default route with an ioctl. Think this is more kosher, but rtnetlink might be the better answer if we want to be really portable.
