### PR TITLE
const-correctness concerns?

### DIFF
--- a/file_descriptor.hh
+++ b/file_descriptor.hh
@@ -44,7 +44,7 @@ public:
         }
     }
 
-    const int & num( void ) { return fd_; }
+    int num( void ) const { return fd_; }
 
     /* forbid copying FileDescriptor objects or assigning them */
     FileDescriptor( const FileDescriptor & other ) = delete;

--- a/signalfd.hh
+++ b/signalfd.hh
@@ -29,7 +29,7 @@ private:
 public:
     SignalFD( const SignalMask & signals );
 
-    const int & raw_fd( void ) { return fd_.num(); }
+    int raw_fd( void ) const { return fd_.num(); }
     signalfd_siginfo read_signal( void ); /* read one signal */
 };
 

--- a/socket.hh
+++ b/socket.hh
@@ -36,7 +36,7 @@ public:
     std::string read( void );
     void write( const std::string & str );
 
-    int raw_fd( void ) { return fd_.num(); }
+    int raw_fd( void ) const { return fd_.num(); }
 
     std::pair< Address, std::string > recvfrom( void );
     void sendto( const Address & destination, const std::string & payload );


### PR DESCRIPTION
Const-correctness fixes. I am not sure why we are returning a const reference to an integer in some cases? Maybe I am missing something.
