### PR TITLE
Smallissues

### DIFF
--- a/chunked_parser.cc
+++ b/chunked_parser.cc
@@ -108,7 +108,7 @@ string::size_type ChunkedBodyParser::compute_ack_size( const string & haystack,
 {
     auto loc = haystack.find( needle );
     if ( loc != string::npos ) {
-        /* Can't find it, eat up the whole buffer */
+        /* Found it, eat up the whole buffer */
         parsed_so_far_ += loc + needle.length();
         assert( parsed_so_far_ > acked_so_far_ );
         return ( parsed_so_far_ - acked_so_far_ );


### PR DESCRIPTION
 Not sure if these changes really help, but they came about as I was going through the chunked parser:

1) fixed spaces so it is consistent with other code in the repo (and with itself)
2) When using string::substr from a position in the string until the end of the string, we can simply put the initial position without the substring length (it will go until the end of the string since count is set to npos by default). 
3) In ChunkedBodyParser::compute_ack_size, loc represents the position we find needle in the haystack. Then, we check whether loc != string::npos which means that we do find the needle in the haystack. So, I modified the comment just below to state that we found the needle rather than saying "Can't find it". 

Please let me know if any of this is wrong!
