### PR TITLE
Fix TUNSETIFF size

### DIFF
--- a/src/util/netdevice.cc
+++ b/src/util/netdevice.cc
@@ -29,7 +29,7 @@ TunDevice::TunDevice( const string & name,
     assign_address( name, addr, peer );
 }
 
-void interface_ioctl( FileDescriptor & fd, const int request,
+void interface_ioctl( FileDescriptor & fd, const unsigned long request,
                       const string & name,
                       function<void( ifreq &ifr )> ifr_adjustment)
 {
@@ -42,7 +42,7 @@ void interface_ioctl( FileDescriptor & fd, const int request,
     SystemCall( "ioctl " + name, ioctl( fd.fd_num(), request, static_cast<void *>( &ifr ) ) );
 }
 
-void interface_ioctl( const int request,
+void interface_ioctl( const unsigned long request,
                       const string & name,
                       function<void( ifreq &ifr )> ifr_adjustment)
 {

--- a/src/util/netdevice.hh
+++ b/src/util/netdevice.hh
@@ -13,11 +13,11 @@
 #include "address.hh"
 
 /* general helpers */
-void interface_ioctl( FileDescriptor & fd, const int request,
+void interface_ioctl( FileDescriptor & fd, const unsigned long request,
                       const std::string & name,
                       std::function<void( ifreq &ifr )> ifr_adjustment);
 
-void interface_ioctl( const int request,
+void interface_ioctl( const unsigned long request,
                       const std::string & name,
                       std::function<void( ifreq &ifr )> ifr_adjustment);
 


### PR DESCRIPTION
This patch changes the type of a variable used in netdevice.cc to
long, since it is causing the compilation to break due to overflow

As provided in
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=806368