### PR TITLE
Tweak argument parsing on mm-loss and mm-onoff

### DIFF
--- a/src/frontend/lossshell.cc
+++ b/src/frontend/lossshell.cc
@@ -31,6 +31,13 @@ int main( int argc, char *argv[] )
             usage( argv[ 0 ] );
         }
 
+        const string link = argv[ 1 ];
+        if ( link == "uplink" or link == "downlink" ) {
+            /* do nothing */
+        } else {
+            usage( argv[ 0 ] );
+        }
+
         const double loss_rate = myatof( argv[ 2 ] );
         if ( (0 <= loss_rate) and (loss_rate <= 1) ) {
             /* do nothing */
@@ -41,13 +48,10 @@ int main( int argc, char *argv[] )
 
         double uplink_loss = 0, downlink_loss = 0;
 
-        const string link = argv[ 1 ];
         if ( link == "uplink" ) {
             uplink_loss = loss_rate;
-        } else if ( link == "downlink" ) {
-            downlink_loss = loss_rate;
         } else {
-            usage( argv[ 0 ] );
+            downlink_loss = loss_rate;
         }
 
         vector<string> command;

--- a/src/frontend/onoffshell.cc
+++ b/src/frontend/onoffshell.cc
@@ -31,6 +31,13 @@ int main( int argc, char *argv[] )
             usage( argv[ 0 ] );
         }
 
+        const string link = argv[ 1 ];
+        if ( link == "uplink" or link == "downlink" ) {
+            /* do nothing */
+        } else {
+            usage( argv[ 0 ] );
+        }
+
         const double on_time = myatof( argv[ 2 ] );
         if ( (0 <= on_time) ) {
             /* do nothing */
@@ -55,15 +62,12 @@ int main( int argc, char *argv[] )
         double uplink_on_time = numeric_limits<double>::max(), uplink_off_time = 0;
         double downlink_on_time = numeric_limits<double>::max(), downlink_off_time = 0;
 
-        const string link = argv[ 1 ];
         if ( link == "uplink" ) {
             uplink_on_time = on_time;
             uplink_off_time = off_time;
-        } else if ( link == "downlink" ) {
+        } else {
             downlink_on_time = on_time;
             downlink_off_time = off_time;
-        } else {
-            usage( argv[ 0 ] );
         }
 
         vector<string> command;


### PR DESCRIPTION
Some common user errors for mm-loss and mm-onoff have confusing failure modes because of how the argument parsing code parses the float argument first. I added a check to make sure the uplink/downlink string argument is checked first instead, adding some complexity to the code but making the program more user friendly.

For `mm-loss .2 ping google.com` the error changes from
`Died on std::runtime_error: Invalid floating-point number: ping`
to `Died on std::runtime_error: Usage: mm-loss uplink|downlink RATE [COMMAND...]`

For `mm-onoff .5 .5 downlink` the error changes from
`Died on std::runtime_error: Invalid floating-point number: downlink`
to `Died on std::runtime_error: Usage: mm-onoff uplink|downlink MEAN-ON-TIME MEAN-OFF-TIME [COMMAND...]`

