### PR TITLE
mm-throughput-graph: assertion avoid gnuplot failure when MS_PER_BIN too large

### DIFF
--- a/scripts/mm-throughput-graph
+++ b/scripts/mm-throughput-graph
@@ -179,6 +179,10 @@ printf STDERR qq{95th percentile signal delay: %.0f ms\n}, $pp95s;
 my $earliest_bin = min( keys %arrivals, keys %capacity, keys %departures );
 my $latest_bin = max( keys %arrivals, keys %capacity, keys %departures );
 
+if ( $earliest_bin == $latest_bin ) {
+  die q{MS_PER_BIN is too large for length of trace};
+}
+
 my $current_buffer_occupancy = 0;
 
 sub default {


### PR DESCRIPTION
Hi, if one has a very short trace they are trying to graph or choose an excessively large MS_PER_BIN in mm-thoughput-graph, gnuplot will fail out with a non-helpful error such as:
```
Average capacity: 8.78 Mbits/s
Average throughput: 0.30 Mbits/s (3.4% utilization)
95th percentile per-packet queueing delay: 9 ms
95th percentile signal delay: 9 ms

gnuplot> plot [0.007000:0.081000] "-" using 1:2 title "Capacity (mean 8.78 Mbits/s)" with filledcurves above x1 lw 0.5, "-" using 1:3 with lines lc rgb "#0020a0" lw 4 title "Traffic ingress (mean 0.30 Mbits/s)", "-" using 1:4 with lines lc rgb "#ff6040" lw 2 title "Traffic egress (mean 0.30 Mbits/s)"
                                                                                                                                                                                                                                                                                                             ^
         line 7: all points y value undefined!

Died at /usr/local/bin/mm-throughput-graph line 220, <> line 62.
```

This commit would prevent this error from happening and instead die like:
```
Average capacity: 12.03 Mbits/s
Average throughput: 0.03 Mbits/s (0.2% utilization)
95th percentile per-packet queueing delay: 8 ms
95th percentile signal delay: 900 ms
Bin size is too large for length of trace at /home/greg/Desktop/mahimahi/scripts/mm-throughput-graph line 183, <> line 4410.
```