### PR TITLE
Add CoDel and PIE AQM packet queues for LinkShell

### DIFF
--- a/src/frontend/linkshell.cc
+++ b/src/frontend/linkshell.cc
@@ -6,6 +6,7 @@
 #include "drop_tail_packet_queue.hh"
 #include "drop_head_packet_queue.hh"
 #include "codel_packet_queue.hh"
+#include "pie_packet_queue.hh"
 #include "link_queue.hh"
 #include "packetshell.cc"
 
@@ -23,9 +24,10 @@ void usage_error( const string & program_name )
     cerr << "          --uplink-queue=QUEUE_TYPE --downlink-queue=QUEUE_TYPE" << endl;
     cerr << "          --uplink-queue-args=QUEUE_ARGS --downlink-queue-args=QUEUE_ARGS" << endl;
     cerr << endl;
-    cerr << "          QUEUE_TYPE = infinite | droptail | drophead | codel" << endl;
+    cerr << "          QUEUE_TYPE = infinite | droptail | drophead | codel | pie" << endl;
     cerr << "          QUEUE_ARGS = \"NAME=NUMBER[, NAME2=NUMBER2, ...]\"" << endl;
-    cerr << "              (with NAME = bytes | packets | target | interval)" << endl << endl;
+    cerr << "              (with NAME = bytes | packets | target | interval | qdelay_ref | max_burst)" << endl;
+    cerr << "                  target, interval, qdelay_ref, max_burst are in milli-second" << endl << endl;
 
     throw runtime_error( "invalid arguments" );
 }
@@ -40,6 +42,8 @@ unique_ptr<AbstractPacketQueue> get_packet_queue( const string & type, const str
         return unique_ptr<AbstractPacketQueue>( new DropHeadPacketQueue( args ) );
     } else if ( type == "codel" ) {
         return unique_ptr<AbstractPacketQueue>( new CODELPacketQueue( args ) );
+    } else if ( type == "pie" ) {
+        return unique_ptr<AbstractPacketQueue>( new PIEPacketQueue( args ) );
     } else {
         cerr << "Unknown queue type: " << type << endl;
     }

--- a/src/frontend/linkshell.cc
+++ b/src/frontend/linkshell.cc
@@ -5,6 +5,7 @@
 #include "infinite_packet_queue.hh"
 #include "drop_tail_packet_queue.hh"
 #include "drop_head_packet_queue.hh"
+#include "codel_packet_queue.hh"
 #include "link_queue.hh"
 #include "packetshell.cc"
 
@@ -22,9 +23,9 @@ void usage_error( const string & program_name )
     cerr << "          --uplink-queue=QUEUE_TYPE --downlink-queue=QUEUE_TYPE" << endl;
     cerr << "          --uplink-queue-args=QUEUE_ARGS --downlink-queue-args=QUEUE_ARGS" << endl;
     cerr << endl;
-    cerr << "          QUEUE_TYPE = infinite | droptail | drophead" << endl;
+    cerr << "          QUEUE_TYPE = infinite | droptail | drophead | codel" << endl;
     cerr << "          QUEUE_ARGS = \"NAME=NUMBER[, NAME2=NUMBER2, ...]\"" << endl;
-    cerr << "              (with NAME = bytes | packets)" << endl << endl;
+    cerr << "              (with NAME = bytes | packets | target | interval)" << endl << endl;
 
     throw runtime_error( "invalid arguments" );
 }
@@ -37,6 +38,8 @@ unique_ptr<AbstractPacketQueue> get_packet_queue( const string & type, const str
         return unique_ptr<AbstractPacketQueue>( new DropTailPacketQueue( args ) );
     } else if ( type == "drophead" ) {
         return unique_ptr<AbstractPacketQueue>( new DropHeadPacketQueue( args ) );
+    } else if ( type == "codel" ) {
+        return unique_ptr<AbstractPacketQueue>( new CODELPacketQueue( args ) );
     } else {
         cerr << "Unknown queue type: " << type << endl;
     }

--- a/src/packet/Makefile.am
+++ b/src/packet/Makefile.am
@@ -6,4 +6,5 @@ noinst_LIBRARIES = libpacket.a
 libpacket_a_SOURCES = packetshell.hh packetshell.cc queued_packet.hh \
                       abstract_packet_queue.hh dropping_packet_queue.hh dropping_packet_queue.cc infinite_packet_queue.hh \
                       drop_tail_packet_queue.hh drop_head_packet_queue.hh \
+                      codel_packet_queue.cc codel_packet_queue.hh \
                       bindworkaround.hh

--- a/src/packet/Makefile.am
+++ b/src/packet/Makefile.am
@@ -7,4 +7,5 @@ libpacket_a_SOURCES = packetshell.hh packetshell.cc queued_packet.hh \
                       abstract_packet_queue.hh dropping_packet_queue.hh dropping_packet_queue.cc infinite_packet_queue.hh \
                       drop_tail_packet_queue.hh drop_head_packet_queue.hh \
                       codel_packet_queue.cc codel_packet_queue.hh \
+                      pie_packet_queue.cc pie_packet_queue.hh \
                       bindworkaround.hh

--- a/src/packet/codel_packet_queue.cc
+++ b/src/packet/codel_packet_queue.cc
@@ -1,0 +1,104 @@
+#include <math.h>
+#include "codel_packet_queue.hh"
+#include "timestamp.hh"
+
+
+using namespace std;
+
+CODELPacketQueue::CODELPacketQueue( const string & args )
+  : DroppingPacketQueue(args),
+    target_ ( get_arg( args, "target") ),
+    interval_ ( get_arg( args, "interval") ),
+    first_above_time_ ( 0 ),
+    drop_next_( 0 ),
+    count_ ( 0 ),
+    lastcount_ ( 0 ),
+    dropping_ ( 0 )
+{
+  if ( target_ == 0 || interval_ == 0 ) {
+    throw runtime_error( "CoDel queue must have target and interval arguments." );
+  }
+}
+
+//NOTE: CoDel makes drop decisions at dequeueing. 
+//However, this function cannot return NULL. Therefore we ignore
+//the drop decision if the current packet is the only one in the queue.
+//We know that if this function is called, there is at least one packet in the queue.
+dodequeue_result CODELPacketQueue::dodequeue ( uint64_t now )
+{
+  uint64_t sojourn_time;
+
+  dodequeue_result r;
+  r.p = std::move( DroppingPacketQueue::dequeue () );
+  r.ok_to_drop = false;
+
+  if ( empty() ) {
+    first_above_time_ = 0;
+    return r;
+  }
+
+  sojourn_time = now - r.p.arrival_time;
+  if ( sojourn_time < target_ || size_bytes() <= PACKET_SIZE ) {
+    first_above_time_ = 0;
+  }
+  else {
+    if ( first_above_time_ == 0 ) {
+      first_above_time_ = now + interval_;
+    }
+    else if (now >= first_above_time_) {
+      r.ok_to_drop = true;
+    }
+  }
+
+  return r;
+}
+
+uint64_t CODELPacketQueue::control_law ( uint64_t t, uint32_t count ) 
+{
+  double d = interval_ / sqrt (count);
+  return t + (uint64_t) d;
+}
+
+QueuedPacket CODELPacketQueue::dequeue( void )
+{   
+  const uint64_t now = timestamp();
+  dodequeue_result r = std::move( dodequeue ( now ) );
+  uint32_t delta;
+    
+  if ( dropping_ ) {
+    if ( !r.ok_to_drop ) {
+      dropping_ = false;
+    }
+
+    while ( now >= drop_next_ && dropping_ ) {
+      dodequeue_result r = std::move( dodequeue ( now ) );
+      count_++;
+      if ( ! r.ok_to_drop ) {
+	dropping_ = false;
+      } else {
+	drop_next_ = control_law(drop_next_, count_);
+      }
+    }
+  }
+  else if ( r.ok_to_drop ) {
+    dodequeue_result r = std::move( dodequeue ( now ) );
+    dropping_ = true;
+    delta = count_ - lastcount_;
+    count_ = ( ( delta > 1 ) && ( now - drop_next_ < 16 * interval_ ))? 
+      delta : 1;
+    drop_next_ = control_law ( now, count_ );
+    lastcount_ = count_;
+  }
+
+  return r.p;
+}
+
+
+void CODELPacketQueue::enqueue( QueuedPacket && p )
+{
+  if ( good_with( size_bytes() + p.contents.size(),
+		  size_packets() + 1 ) ) {
+    accept( std::move( p ) );
+  }
+  assert( good() );
+}

--- a/src/packet/codel_packet_queue.hh
+++ b/src/packet/codel_packet_queue.hh
@@ -1,0 +1,55 @@
+/* -*-mode:c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+#ifndef CODEL_PACKET_QUEUE_HH
+#define CODEL_PACKET_QUEUE_HH
+
+#include <random>
+#include "dropping_packet_queue.hh"
+
+struct dodequeue_result {
+    QueuedPacket p;
+    bool ok_to_drop;
+
+    dodequeue_result ( )
+        : p ( "", 0 ), ok_to_drop ( false )
+    {}
+};
+
+/*
+   Controlled Delay (CoDel) AQM Implementation
+   based on IETF draft-ietf-aqm-codel-04
+   and the CoDel implementation in Linux 4.4
+   Contributed by
+      Joseph D. Beshay <joseph.beshay@utdallas.edu>
+*/
+class CODELPacketQueue : public DroppingPacketQueue
+{
+private:
+    const static unsigned int PACKET_SIZE = 1504;
+    //Configuration parameters
+    uint32_t target_, interval_;
+
+    //State variables
+    uint64_t first_above_time_, drop_next_;
+    uint32_t count_, lastcount_;
+    bool dropping_;
+
+
+    virtual const std::string & type( void ) const override
+    {
+        static const std::string type_ { "codel" };
+        return type_;
+    }
+
+    dodequeue_result dodequeue ( uint64_t now );
+    uint64_t control_law ( uint64_t t, uint32_t count );
+
+public:
+    CODELPacketQueue( const std::string & args );
+
+    void enqueue( QueuedPacket && p ) override;
+
+    QueuedPacket dequeue( void ) override;
+};
+
+#endif /* PIE_PACKET_QUEUE_HH */ 

--- a/src/packet/dropping_packet_queue.cc
+++ b/src/packet/dropping_packet_queue.cc
@@ -8,38 +8,6 @@
 
 using namespace std;
 
-static unsigned int get_arg( const string & args, const string & name )
-{
-    auto offset = args.find( name );
-    if ( offset == string::npos ) {
-        return 0; /* default value */
-    } else {
-        /* extract the value */
-
-        /* advance by length of name */
-        offset += name.size();
-
-        /* make sure next char is "=" */
-        if ( args.substr( offset, 1 ) != "=" ) {
-            throw runtime_error( "could not parse queue arguments: " + args );
-        }
-
-        /* advance by length of "=" */
-        offset++;
-
-        /* find the first non-digit character */
-        auto offset2 = args.substr( offset ).find_first_not_of( "0123456789" );
-
-        auto digit_string = args.substr( offset ).substr( 0, offset2 );
-
-        if ( digit_string.empty() ) {
-            throw runtime_error( "could not parse queue arguments: " + args );
-        }
-
-        return myatoi( digit_string );
-    }
-}
-
 DroppingPacketQueue::DroppingPacketQueue( const string & args )
     : packet_limit_( get_arg( args, "packets" ) ),
       byte_limit_( get_arg( args, "bytes" ) )
@@ -129,4 +97,36 @@ string DroppingPacketQueue::to_string( void ) const
     ret += "]";
 
     return ret;
+}
+
+unsigned int DroppingPacketQueue::get_arg( const string & args, const string & name )
+{
+    auto offset = args.find( name );
+    if ( offset == string::npos ) {
+        return 0; /* default value */
+    } else {
+        /* extract the value */
+
+        /* advance by length of name */
+        offset += name.size();
+
+        /* make sure next char is "=" */
+        if ( args.substr( offset, 1 ) != "=" ) {
+            throw runtime_error( "could not parse queue arguments: " + args );
+        }
+
+        /* advance by length of "=" */
+        offset++;
+
+        /* find the first non-digit character */
+        auto offset2 = args.substr( offset ).find_first_not_of( "0123456789" );
+
+        auto digit_string = args.substr( offset ).substr( 0, offset2 );
+
+        if ( digit_string.empty() ) {
+            throw runtime_error( "could not parse queue arguments: " + args );
+        }
+
+        return myatoi( digit_string );
+    }
 }

--- a/src/packet/dropping_packet_queue.hh
+++ b/src/packet/dropping_packet_queue.hh
@@ -7,6 +7,7 @@
 #include <cassert>
 
 #include "abstract_packet_queue.hh"
+#include "exception.hh"
 
 class DroppingPacketQueue : public AbstractPacketQueue
 {
@@ -42,6 +43,8 @@ public:
     bool empty( void ) const override;
 
     std::string to_string( void ) const override;
+
+    static unsigned int get_arg( const std::string & args, const std::string & name );
 };
 
 #endif /* DROPPING_PACKET_QUEUE_HH */ 

--- a/src/packet/pie_packet_queue.cc
+++ b/src/packet/pie_packet_queue.cc
@@ -1,0 +1,188 @@
+
+#include <chrono>
+
+#include "pie_packet_queue.hh"
+#include "timestamp.hh"
+
+using namespace std;
+
+#define DQ_COUNT_INVALID   (uint32_t)-1
+
+PIEPacketQueue::PIEPacketQueue( const string & args )
+  : DroppingPacketQueue(args),
+    qdelay_ref_ ( get_arg( args, "qdelay_ref" ) ),
+    max_burst_ ( get_arg( args, "max_burst" ) ),
+    alpha_ ( 0.125 ),
+    beta_ ( 1.25 ),
+    t_update_ ( 30 ),
+    dq_threshold_ ( 16384 ),
+    drop_prob_ ( 0.0 ),
+    burst_allowance_ ( 0 ),
+    qdelay_old_ ( 0 ),
+    current_qdelay_ ( 0 ),
+    dq_count_ ( DQ_COUNT_INVALID ),
+    dq_tstamp_ ( 0 ),
+    avg_dq_rate_ ( 0 ),
+    uniform_generator_ ( 0.0, 1.0 ),
+    prng_( random_device()() ),
+    last_update_( timestamp() )
+{
+  if ( qdelay_ref_ == 0 || max_burst_ == 0 ) {
+    throw runtime_error( "PIE AQM queue must have qdelay_ref and max_burst parameters" );
+  }
+}
+
+void PIEPacketQueue::enqueue( QueuedPacket && p )
+{
+  calculate_drop_prob();
+
+  if ( ! good_with( size_bytes() + p.contents.size(),
+		    size_packets() + 1 ) ) {
+    // Internal queue is full. Packet has to be dropped.
+    return;
+  } 
+
+  if (!drop_early() ) {
+    //This is the negation of the pseudo code in the IETF draft.
+    //It is used to enqueue rather than drop the packet
+    //All other packets are dropped
+    accept( std::move( p ) );
+  }
+
+  assert( good() );
+}
+
+//returns true if packet should be dropped.
+bool PIEPacketQueue::drop_early ()
+{
+  if ( burst_allowance_ > 0 ) {
+    return false;
+  }
+
+  if ( qdelay_old_ < qdelay_ref_/2 && drop_prob_ < 0.2) {
+    return false;        
+  }
+
+  if ( size_bytes() < (2 * PACKET_SIZE) ) {
+    return false;
+  }
+
+  double random = uniform_generator_(prng_);
+
+  if ( random < drop_prob_ ) {
+    return true;
+  }
+  else
+    return false;
+}
+
+QueuedPacket PIEPacketQueue::dequeue( void )
+{
+  QueuedPacket ret = std::move( DroppingPacketQueue::dequeue () );
+  uint32_t now = timestamp();
+
+  if ( size_bytes() >= dq_threshold_ && dq_count_ == DQ_COUNT_INVALID ) {
+    dq_tstamp_ = now;
+    dq_count_ = 0;
+  }
+
+  if ( dq_count_ != DQ_COUNT_INVALID ) {
+    dq_count_ += ret.contents.size();
+
+    if ( dq_count_ > dq_threshold_ ) {
+      uint32_t dtime = now - dq_tstamp_;
+
+      if ( dtime > 0 ) {
+	uint32_t rate_sample = dq_count_ / dtime;
+	if ( avg_dq_rate_ == 0 ) 
+	  avg_dq_rate_ = rate_sample;
+	else
+	  avg_dq_rate_ = ( avg_dq_rate_ - (avg_dq_rate_ >> 3 )) +
+		     (rate_sample >> 3);
+                
+	if ( size_bytes() < dq_threshold_ ) {
+	  dq_count_ = DQ_COUNT_INVALID;
+	}
+	else {
+	  dq_count_ = 0;
+	  dq_tstamp_ = now;
+	} 
+
+	if ( burst_allowance_ > 0 ) {
+	  if ( burst_allowance_ > dtime )
+	    burst_allowance_ -= dtime;
+	  else
+	    burst_allowance_ = 0;
+	}
+      }
+    }
+  }
+
+  calculate_drop_prob();
+
+  return ret;
+}
+
+void PIEPacketQueue::calculate_drop_prob( void )
+{
+  uint64_t now = timestamp();
+
+  //We can't have a fork inside the mahimahi shell so we simulate
+  //the periodic drop probability calculation here by repeating it for the
+  //number of periods missed since the last update. 
+  //In the interval [last_update_, now] no change occured in queue occupancy 
+  //so when this value is used (at enqueue) it will be identical
+  //to that of a timer-based drop probability calculation.
+  while (now - last_update_ > t_update_) {
+    bool update_prob = true;
+    qdelay_old_ = current_qdelay_;
+
+    if ( avg_dq_rate_ > 0 ) 
+      current_qdelay_ = size_bytes() / avg_dq_rate_;
+    else
+      current_qdelay_ = 0;
+
+    if ( current_qdelay_ == 0 && size_bytes() != 0 ) {
+      update_prob = false;
+    }
+
+    double p = (alpha_ * (int)(current_qdelay_ - qdelay_ref_) ) +
+      ( beta_ * (int)(current_qdelay_ - qdelay_old_) );
+
+    if ( drop_prob_ < 0.01 ) {
+      p /= 128;
+    } else if ( drop_prob_ < 0.1 ) {
+      p /= 32;
+    } else  {
+      p /= 16;
+    } 
+
+    drop_prob_ += p;
+
+    if ( drop_prob_ < 0 ) {
+      drop_prob_ = 0;
+    }
+    else if ( drop_prob_ > 1 ) {
+      drop_prob_ = 1;
+      update_prob = false;
+    }
+
+        
+    if ( current_qdelay_ == 0 && qdelay_old_==0 && update_prob) {
+      drop_prob_ *= 0.98;
+    }
+        
+    burst_allowance_ = max( 0, (int) burst_allowance_ -  (int)t_update_ );
+    last_update_ += t_update_;
+
+    if ( ( drop_prob_ == 0 )
+	 && ( current_qdelay_ < qdelay_ref_/2 ) 
+	 && ( qdelay_old_ < qdelay_ref_/2 ) 
+	 && ( avg_dq_rate_ > 0 ) ) {
+      dq_count_ = DQ_COUNT_INVALID;
+      avg_dq_rate_ = 0;
+      burst_allowance_ = max_burst_;
+    }
+
+  }
+}

--- a/src/packet/pie_packet_queue.hh
+++ b/src/packet/pie_packet_queue.hh
@@ -1,0 +1,62 @@
+/* -*-mode:c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+#ifndef PIE_PACKET_QUEUE_HH
+#define PIE_PACKET_QUEUE_HH
+
+#include <random>
+#include <thread>
+#include "dropping_packet_queue.hh"
+
+/*    
+   Proportional Integral controller Enhanced (PIE)
+   AQM Implementation based on draft-ietf-aqm-pie-09
+   and the PIE implementation in Linux 4.4
+   Contributed by
+      Joseph D. Beshay <joseph.beshay@utdallas.edu>
+*/
+class PIEPacketQueue : public DroppingPacketQueue
+{
+private:
+    //This constant is copied from link_queue.hh.
+    //It maybe better to get this in a more reliable way in the future.
+    const static unsigned int PACKET_SIZE = 1504; /* default max TUN payload size */
+
+    //Configurable parameters
+    uint32_t qdelay_ref_, max_burst_;
+
+    //Internal parameters
+    double alpha_, beta_;
+    uint32_t t_update_;     // ms
+    uint32_t dq_threshold_; // bytes
+
+    //Status variables
+    double drop_prob_;
+    uint32_t burst_allowance_, qdelay_old_, current_qdelay_;
+    uint32_t dq_count_, dq_tstamp_, avg_dq_rate_;
+
+    //Implementation specific
+    std::uniform_real_distribution<double> uniform_generator_;
+    std::default_random_engine prng_;
+    uint64_t last_update_;
+    
+
+
+    virtual const std::string & type( void ) const override
+    {
+        static const std::string type_ { "pie" };
+        return type_;
+    }
+
+    bool drop_early ( void );
+
+    void calculate_drop_prob ( void );
+
+public:
+    PIEPacketQueue( const std::string & args );
+
+    void enqueue( QueuedPacket && p ) override;
+
+    QueuedPacket dequeue( void ) override;
+};
+
+#endif /* PIE_PACKET_QUEUE_HH */ 


### PR DESCRIPTION
Mahimahi implementations for CoDel and PIE AQM mechanisms based on the respective IETF drafts and Linux implementations in Linux 4.4.

Note: No ECN support. Only packet dropping.