### PR TITLE
http proxy sends sni servername

### DIFF
--- a/src/httpserver/http_proxy.cc
+++ b/src/httpserver/http_proxy.cc
@@ -105,11 +105,16 @@ void HTTPProxy::handle_tcp( HTTPBackingStore & backing_store )
                 }
 
                 /* handle TLS */
-                SecureSocket tls_server( client_context_.new_secure_socket( move( server ) ) );
-                tls_server.connect();
-
                 SecureSocket tls_client( server_context_.new_secure_socket( move( client ) ) );
+                SecureSocket tls_server( client_context_.new_secure_socket( move( server ) ) );
+
                 tls_client.accept();
+                std::string servername;
+                if ( tls_client.get_sni_servername( servername ) ) {
+                    tls_server.set_sni_servername_sent( servername );
+                }
+
+                tls_server.connect();
 
                 loop( tls_server, tls_client, backing_store );
             } catch ( const exception & e ) {

--- a/src/httpserver/secure_socket.hh
+++ b/src/httpserver/secure_socket.hh
@@ -29,6 +29,12 @@ public:
 
     std::string read( void );
     void write( const std::string & message );
+
+    /* if an SNI servername has been received, assigns it to servername and returns true;
+     * returns false otherwise */
+    bool get_sni_servername( std::string & servername );
+    /* make the socket send the specified servername when connecting to a server */
+    void set_sni_servername_sent( const std::string & servername );
 };
 
 class SSLContext


### PR DESCRIPTION
We noticed that when a client connects to a `HttpProxy` (during recording) using HTTPS and sends over a SNI host name, the proxy doesn't pass on the host name when it connects to the real server. As a result, the connection might fail if the server requires that a SNI host name be sent.

We discovered this problem as we encountered this error message a bunch of times when recording [washingtonpost.com](washingtonpost.com):

> Died on ssl_error: SSL_read: error:14077410:SSL routines:SSL23_GET_SERVER_HELLO:sslv3 alert handshake failure

This pull request tries to fix this problem. Although the code isn't well-written, Keith said we should send a pull request anyway.

-Wen (@zhangwen0411) and Ernest (@jxguan)