### PR TITLE
Add RED AQM.

### DIFF
--- a/src/frontend/linkshell.cc
+++ b/src/frontend/linkshell.cc
@@ -7,6 +7,7 @@
 #include "drop_head_packet_queue.hh"
 #include "codel_packet_queue.hh"
 #include "pie_packet_queue.hh"
+#include "red_packet_queue.hh"
 #include "link_queue.hh"
 #include "packetshell.cc"
 
@@ -44,6 +45,8 @@ unique_ptr<AbstractPacketQueue> get_packet_queue( const string & type, const str
         return unique_ptr<AbstractPacketQueue>( new CODELPacketQueue( args ) );
     } else if ( type == "pie" ) {
         return unique_ptr<AbstractPacketQueue>( new PIEPacketQueue( args ) );
+    } else if ( type == "red" ) {
+        return unique_ptr<AbstractPacketQueue>( new REDPacketQueue( args ) );
     } else {
         cerr << "Unknown queue type: " << type << endl;
     }
@@ -96,8 +99,8 @@ int main( int argc, char *argv[] )
             { "meter-downlink-delay",       no_argument, nullptr, 'y' },
             { "meter-all",                  no_argument, nullptr, 'z' },
             { "uplink-queue",         required_argument, nullptr, 'q' },
-            { "downlink-queue",       required_argument, nullptr, 'w' },
             { "uplink-queue-args",    required_argument, nullptr, 'a' },
+            { "downlink-queue",         required_argument, nullptr, 'w' },
             { "downlink-queue-args",  required_argument, nullptr, 'b' },
             { 0,                                      0, nullptr, 0 }
         };

--- a/src/packet/Makefile.am
+++ b/src/packet/Makefile.am
@@ -7,5 +7,6 @@ libpacket_a_SOURCES = packetshell.hh packetshell.cc queued_packet.hh \
                       abstract_packet_queue.hh dropping_packet_queue.hh dropping_packet_queue.cc infinite_packet_queue.hh \
                       drop_tail_packet_queue.hh drop_head_packet_queue.hh \
                       codel_packet_queue.cc codel_packet_queue.hh \
+											red_packet_queue.cc red_packet_queue.hh \
                       pie_packet_queue.cc pie_packet_queue.hh \
                       bindworkaround.hh

--- a/src/packet/dropping_packet_queue.cc
+++ b/src/packet/dropping_packet_queue.cc
@@ -99,11 +99,11 @@ string DroppingPacketQueue::to_string( void ) const
     return ret;
 }
 
-unsigned int DroppingPacketQueue::get_arg( const string & args, const string & name )
+string DroppingPacketQueue::parse_number_arg(const string & args, const string & name, bool isfloat)
 {
     auto offset = args.find( name );
     if ( offset == string::npos ) {
-        return 0; /* default value */
+        return ""; /* default value */
     } else {
         /* extract the value */
 
@@ -112,21 +112,52 @@ unsigned int DroppingPacketQueue::get_arg( const string & args, const string & n
 
         /* make sure next char is "=" */
         if ( args.substr( offset, 1 ) != "=" ) {
-            throw runtime_error( "could not parse queue arguments: " + args );
+            throw runtime_error( "could not parse queue arguments: " + args);
         }
 
         /* advance by length of "=" */
         offset++;
 
-        /* find the first non-digit character */
-        auto offset2 = args.substr( offset ).find_first_not_of( "0123456789" );
+        /* find the first non-valid character */
+        string validchars;
+        if (isfloat) {
+            validchars = "0123456789.";
+        } else {
+            validchars = "0123456789";
+        }
+        auto offset2 = args.substr( offset ).find_first_not_of( validchars );
 
         auto digit_string = args.substr( offset ).substr( 0, offset2 );
 
         if ( digit_string.empty() ) {
             throw runtime_error( "could not parse queue arguments: " + args );
         }
+        return digit_string;
+    }
+}
+
+unsigned int DroppingPacketQueue::get_arg( const string & args, const string & name)
+{
+    auto offset = args.find( name );
+    if ( offset == string::npos ) {
+        return 0; /* default value */
+    } else {
+        auto digit_string = parse_number_arg(args, name, false);
 
         return myatoi( digit_string );
     }
 }
+
+double DroppingPacketQueue::get_float_arg( const string & args, const string & name)
+{
+    auto offset = args.find( name );
+    if ( offset == string::npos ) {
+        return 0; /* default value */
+    } else {
+        auto digit_string = parse_number_arg(args, name, true);
+        return myatof( digit_string );
+    }
+
+}
+
+

--- a/src/packet/dropping_packet_queue.hh
+++ b/src/packet/dropping_packet_queue.hh
@@ -44,7 +44,9 @@ public:
 
     std::string to_string( void ) const override;
 
+    static std::string parse_number_arg(const std::string & args, const std::string & name, bool isfloat);
     static unsigned int get_arg( const std::string & args, const std::string & name );
+    static double get_float_arg( const std::string & args, const std::string & name );
 };
 
 #endif /* DROPPING_PACKET_QUEUE_HH */ 

--- a/src/packet/red_packet_queue.cc
+++ b/src/packet/red_packet_queue.cc
@@ -1,0 +1,50 @@
+#include "red_packet_queue.hh"
+#include <algorithm>
+
+using namespace std;
+
+REDPacketQueue::REDPacketQueue( const string & args)
+  : DroppingPacketQueue(args),
+    wq_(get_float_arg(args, "wq")),
+    min_thresh_(get_float_arg(args, "minthresh")),
+    max_thresh_(get_float_arg(args, "maxthresh"))
+{
+  if ( wq_ == 0.0 || min_thresh_ == 0.0 || max_thresh_ == 0.0 ) {
+    throw runtime_error( "RED queue must have wq, minthresh, and maxthresh arguments." );
+  }
+
+}
+
+unsigned int REDPacketQueue::max_queue_depth_packets (void ) const {
+  if (packet_limit_) {
+    return packet_limit_;
+  } else if (byte_limit_ ) {
+    return byte_limit_ / PACKET_SIZE;
+  } else {
+      throw runtime_error( "No queue limit provided");
+  }
+}
+
+void REDPacketQueue::enqueue( QueuedPacket && p )
+{
+    auto instantaneous_queue_size = size_packets();
+    auto ratio = (weighted_average_)/max_queue_depth_packets();
+    std::default_random_engine generator (0);
+    std::uniform_real_distribution<double> distribution (min_thresh_, max_thresh_);
+    double threshold = distribution(generator);
+    if (ratio > max_thresh_) {
+      ratio = 1;
+    }
+    if (ratio < min_thresh_) {
+      ratio = 0;
+    }
+
+    if ( (threshold > ratio) && good_with( size_bytes() + p.contents.size(),
+                    size_packets() + 1 ) ) {
+        accept( std::move( p ) );
+    }
+
+    weighted_average_ = (instantaneous_queue_size * wq_ ) + (1- wq_) * weighted_average_;
+
+    assert( good() );
+}

--- a/src/packet/red_packet_queue.hh
+++ b/src/packet/red_packet_queue.hh
@@ -1,0 +1,44 @@
+/* -*-mode:c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+#ifndef RED_PACKET_QUEUE_HH
+#define RED_PACKET_QUEUE_HH
+
+#include <string>
+#include "util.hh"
+#include <iostream>
+
+#include <fstream>
+#include <memory>
+#include <deque>
+#include <random>
+#include "dropping_packet_queue.hh"
+
+/*
+   Random Early Detection (RED) AQM Implementation.
+   See section 3 of https://tools.ietf.org/html/rfc2309#ref-Jacobson88
+   for a description of the queuing discipline.
+   j
+
+*/
+class REDPacketQueue : public DroppingPacketQueue
+{
+private:
+    //Configuration parameters
+    const static unsigned int PACKET_SIZE = 1504;
+    double wq_, min_thresh_, max_thresh_;
+
+    const std::string & type( void ) const override
+    {
+        static const std::string type_ { "red" };
+        return type_;
+    }
+
+    double weighted_average_ = 0;
+    unsigned int max_queue_depth_packets() const;
+
+public:
+    REDPacketQueue( const std::string & args );
+    void enqueue( QueuedPacket && p ) override;
+};
+
+#endif


### PR DESCRIPTION
Hey there,

@vsrinivas and I were working on experimenting with different congestion control schemes and wanted to try out our congestion control schemes w/ different queueing disciplines. We were particularly interested in [RED](https://en.wikipedia.org/wiki/Random_early_detection), and wrote an implementation in mahimahi to try out.

There's a high level overview of the algorithm in [this RFC](https://tools.ietf.org/html/rfc2309#section-3), and more detail in this [paper](http://www.icir.org/floyd/papers/early.twocolumn.pdf).

### Algorithm & Parameters

The general idea behind RED is that it drops packets probabilistically, where that probability is determined by an exponentially weighted average of the depth of the queue.

There are three parameters:

* `wq`: This is a weight that governs how heavily to weight the the current depth of the queue when updating the weighted average. The higher this is, the more reactive RED is to random bursts of packets
* `minthresh`: This is the minimum threshold to drop packets (as a % of the queue size). If the queue depth is is below min_thresh, no packets are dropped
*  `maxthresh`: This is the point at which *all* packets are dropped (as a % of the queue size)

The paper I link to above has a guide for how to tune these parameters.

Thanks for putting the simulator on github--it's been super helpful in learning how this congestion control stuff works, and let me know if you'd like to make any changes here.