### PR TITLE
Log dropped packets

### DIFF
--- a/man/mm-link.1
+++ b/man/mm-link.1
@@ -2,7 +2,7 @@
 .\" First parameter, NAME, should be all caps
 .\" Second parameter, SECTION, should be 1-8, maybe w/ subsection
 .\" other parameters are allowed: see man(7), man(1)
-.TH mm-link 1 "February 2014"
+.TH mm-link 1 "October 2018"
 .\" Please adjust this date whenever revising the manpage.
 .\"
 .\" Some roff macros, for reference:
@@ -49,6 +49,49 @@ flexibly create links with a user-supplied one-way delay and a user-supplied
 link rate.
 
 To exit mm-link, simply type "exit" or CTRL-D inside mm-link.
+
+.SH OUTPUT
+mm-link can optionally log detailed performance information for both the uplink and downlink, specified with the \fB--uplink-log\fR and \fB--downlink-log\fR flags respectively. A log file has the following format:
+
+.EX
+# mahimahi mm-link (name of link) [/path/to/trace] > /path/to/log
+# command line: [command used to run mm-link]
+# queue: [queue information]
+# init timestamp: [start time of mm-link]
+# base timestamp: [starting log timestamp]
+[# mahimahi config: [mahimahi shell prefix]]
+[log lines]
+.EE
+
+Each log line is one of the following:
+
+[timestamp] # packet_size
+.
+.IP ""
+.RS
+An unused delivery opportunity.
+.RE
+
+[timestamp] + packet_size
+.
+.IP ""
+.RS
+A packet arrival to the link, it may be dropped later
+.RE
+
+[timestamp] - packet_size
+.
+.IP ""
+.RS
+A successful packet delivery
+.RE
+
+[timestamp] d packets_dropped bytes_dropped
+.
+.IP ""
+.RS
+A dropped packet (or multiple packets)
+.RE
 
 .SH EXAMPLE
 

--- a/src/frontend/link_queue.hh
+++ b/src/frontend/link_queue.hh
@@ -39,6 +39,7 @@ private:
     void use_a_delivery_opportunity( void );
 
     void record_arrival( const uint64_t arrival_time, const size_t pkt_size );
+    void record_drop( const uint64_t time, const size_t pkts_dropped, const size_t bytes_dropped );
     void record_departure_opportunity( void );
     void record_departure( const uint64_t departure_time, const QueuedPacket & packet );
 

--- a/src/packet/abstract_packet_queue.hh
+++ b/src/packet/abstract_packet_queue.hh
@@ -19,6 +19,9 @@ public:
     virtual ~AbstractPacketQueue() = default;
 
     virtual std::string to_string( void ) const = 0;
+
+    virtual unsigned int size_bytes( void ) const = 0;
+    virtual unsigned int size_packets( void ) const = 0;
 };
 
 #endif /* ABSTRACT_PACKET_QUEUE */ 

--- a/src/packet/dropping_packet_queue.hh
+++ b/src/packet/dropping_packet_queue.hh
@@ -22,9 +22,6 @@ protected:
     const unsigned int packet_limit_;
     const unsigned int byte_limit_;
 
-    unsigned int size_bytes( void ) const;
-    unsigned int size_packets( void ) const;
-
     /* put a packet on the back of the queue */
     void accept( QueuedPacket && p );
 
@@ -45,6 +42,9 @@ public:
     std::string to_string( void ) const override;
 
     static unsigned int get_arg( const std::string & args, const std::string & name );
+
+    unsigned int size_bytes( void ) const override;
+    unsigned int size_packets( void ) const override;
 };
 
 #endif /* DROPPING_PACKET_QUEUE_HH */ 

--- a/src/packet/infinite_packet_queue.hh
+++ b/src/packet/infinite_packet_queue.hh
@@ -14,6 +14,7 @@ class InfinitePacketQueue : public AbstractPacketQueue
 {
 private:
     std::queue<QueuedPacket> internal_queue_ {};
+    int queue_size_in_bytes_ = 0, queue_size_in_packets_ = 0;
 
 public:
     InfinitePacketQueue( const std::string & args )
@@ -25,6 +26,8 @@ public:
 
     void enqueue( QueuedPacket && p ) override
     {
+        queue_size_in_bytes_ += p.contents.size();
+        queue_size_in_packets_++;
         internal_queue_.emplace( std::move( p ) );
     }
 
@@ -34,6 +37,10 @@ public:
 
         QueuedPacket ret = std::move( internal_queue_.front() );
         internal_queue_.pop();
+
+        queue_size_in_bytes_ -= ret.contents.size();
+        queue_size_in_packets_--;
+
         return ret;
     }
 
@@ -46,6 +53,19 @@ public:
     {
         return "infinite";
     }
+
+    unsigned int size_bytes( void ) const override
+    {
+        assert( queue_size_in_bytes_ >= 0 );
+        return unsigned( queue_size_in_bytes_ );
+    }
+
+    unsigned int size_packets( void ) const override
+    {
+        assert( queue_size_in_packets_ >= 0 );
+        return unsigned( queue_size_in_packets_ );
+    }
+
 };
 
 #endif /* INFINITE_PACKET_QUEUE_HH */ 


### PR DESCRIPTION
Hi!

I've been using pantheon to do some tests of queue lengths for different congestion control algorithms. There was some strange looking behavior, because mahimahi's LinkQueue logs every packet received, not every packet successfully enqueued. Here's a graph of the queue length over time for ten cubic flows with a drop-tail queue with a 100 packet limit, generated from the mahimahi log:

![image](https://user-images.githubusercontent.com/113292/46754472-660b6f00-cc77-11e8-82f5-a722e9edd386.png)

This patch adds a new log entry for dropped packets, which looks like: `[time] d [packet size]`. With the patch, the queue length for ten cubic flows and a maximum queue length of 100 looks more reasonable:

![image](https://user-images.githubusercontent.com/113292/46754675-dd410300-cc77-11e8-8554-a901ca794482.png)

One note: with this patch, the drop-head queue won't log dropped packets (it's a little tricky, because we would like to log the size of the dropped packet, not the received packet). If you had a suggestion for how to do that, I'm happy to make the change.