### PR TITLE
debian/rules: Pass IPTABLES and IP to configure.

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -14,6 +14,9 @@ DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 %:
 	dh $@ --with autoreconf
 
+override_dh_auto_configure:
+	dh_auto_configure -- IPTABLES=/sbin/iptables IP=/bin/ip
+
 override_dh_fixperms-arch:
 	dh_fixperms
 	chmod 4755 debian/mahimahi/usr/bin/mm-delay


### PR DESCRIPTION
The paths to "iptables" and "ip" may be loated in /sbin and /bin or
/usr/sbin and /usr/bin if the system is configured as a usrmerge
system. Specify the the most compatible locations in /sbin and /bin.

https://tests.reproducible-builds.org/debian/issues/unstable/paths_vary_due_to_usrmerge_issue.html