### PR TITLE
Fix compilation with -Wstringop-truncation

### DIFF
--- a/src/util/netdevice.cc
+++ b/src/util/netdevice.cc
@@ -35,7 +35,7 @@ void interface_ioctl( FileDescriptor & fd, const unsigned long request,
 {
     ifreq ifr;
     zero( ifr );
-    strncpy( ifr.ifr_name, name.c_str(), IFNAMSIZ ); /* interface name */
+    memcpy( ifr.ifr_name, name.c_str(), IFNAMSIZ ); /* interface name */
 
     ifr_adjustment( ifr );
 


### PR DESCRIPTION
I've tried to compile mahimahi on Ubuntu 20.04, ARM64 Mac M1 and got an error while compiling due to stringop-truncation warning set as error.

This line fixes the compilation.

See [here](https://stackoverflow.com/questions/50198319/gcc-8-wstringop-truncation-what-is-the-good-practice) for more information.