### PR TITLE
Import <cstdint> where uint32_t is used

### DIFF
--- a/src/http/chunked_parser.hh
+++ b/src/http/chunked_parser.hh
@@ -3,6 +3,7 @@
 #ifndef CHUNKED_BODY_PARSER_HH
 #define CHUNKED_BODY_PARSER_HH
 
+#include <cstdint>
 #include "body_parser.hh"
 #include "exception.hh"
 

--- a/src/packet/queued_packet.hh
+++ b/src/packet/queued_packet.hh
@@ -4,6 +4,7 @@
 #define QUEUED_PACKET_HH
 
 #include <string>
+#include <cstdint>
 
 struct QueuedPacket
 {


### PR DESCRIPTION
Attempting to build MM yesterday led to a couple compile errors, presumably due to new versions of GCC in the Fedora repo. This PR fixes them.

```
In file included from chunked_parser.cc:6:
chunked_parser.hh:15:5: error: 'uint32_t' does not name a type
   15 |     uint32_t get_chunk_size(const std::string & chunk_hdr) const;
      |     ^~~~~~~~
chunked_parser.hh:8:1: note: 'uint32_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
    7 | #include "exception.hh"
  +++ |+#include <cstdint>
    8 | 
chunked_parser.hh:17:5: error: 'uint32_t' does not name a type
   17 |     uint32_t current_chunk_size_ {0};
      |     ^~~~~~~~
chunked_parser.hh:17:5: note: 'uint32_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
```